### PR TITLE
allow user events to trigger

### DIFF
--- a/.idea/RedQueen.iml
+++ b/.idea/RedQueen.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="ProjectAlice" />
+  </component>
+</module>

--- a/RedQueen.install
+++ b/RedQueen.install
@@ -1,15 +1,16 @@
 {
-    "name": "RedQueen",
-    "version": "1.0.32",
-    "icon": "fas fa-biohazard",
-    "category": "alice",
-    "author": "ProjectAlice",
-    "maintainers": [
-        "Psycho",
-        "maxbachmann"
-    ],
-    "desc": "Red Queen is the official Project Alice personality skill",
-    "aliceMinVersion": "1.0.0-b4",
+	"name": "RedQueen",
+	"version": "1.0.33",
+	"icon": "fas fa-biohazard",
+	"category": "alice",
+	"author": "ProjectAlice",
+	"maintainers": [
+		"Psycho",
+		"maxbachmann",
+		"lazza"
+	],
+	"desc": "Red Queen is the official Project Alice personality skill",
+	"aliceMinVersion": "1.0.0-b4",
     "systemRequirements": [],
     "pipRequirements": [],
     "conditions": {

--- a/RedQueen.py
+++ b/RedQueen.py
@@ -192,18 +192,23 @@ class RedQueen(AliceSkill):
 	@IntentHandler('ChangeUserState')
 	def userStateIntent(self, session: DialogSession):
 		slots = session.slotsAsObjects
+
 		if 'State' not in slots.keys():
 			self.logError('No state provided for changing user state')
-			self.endDialog(sessionId=session.sessionId, text=self.TalkManager.randomTalk('error', skill='system'), siteId=session.siteId)
+			self.endDialog(sessionId=session.sessionId, text=self.TalkManager.randomTalk('error', skill='system'),
+						   siteId=session.siteId)
 			return
 
-		if not 'Who' in slots.keys():
-			try:
-				self.SkillManager.skillBroadcast(slots['State'][0].value['value'])
-			except:
-				self.logWarning(f"Unsupported user state \"{slots['State'][0].value['value']}\"")
+		# Todo re enable this if statement when the "personDesignation" code gets fully implemented
+		# if not 'Who' in slots.keys():
+		try:
+			self.SkillManager.skillBroadcast(slots['State'][0].value['value'])
 
-		self.endDialog(sessionId=session.sessionId, text=self.TalkManager.randomTalk(slots['State'][0].value['value']), siteId=session.siteId)
+		except:
+			self.logWarning(f"Unsupported user state \"{slots['State'][0].value['value']}\"")
+
+		self.endDialog(sessionId=session.sessionId, text=self.TalkManager.randomTalk(slots['State'][0].value['value']),
+					   siteId=session.siteId)
 
 
 	def randomlySpeak(self, init: bool = False):

--- a/dialogTemplate/en.json
+++ b/dialogTemplate/en.json
@@ -77,14 +77,19 @@
 				{
 					"value": "i",
 					"synonyms": [
-						"i'm"
+						"i'm",
+						"i've",
+						"i have",
+						"i am"
 					]
 				},
 				{
 					"value": "we",
 					"synonyms": [
 						"us",
-						"we're"
+						"we're",
+						"we are",
+						"we have"
 					]
 				}
 			]
@@ -170,12 +175,14 @@
 				"time for {going bed:=>State}",
 				"{we:=>Who} are {cooking:=>State}",
 				"{i:=>Who} am putting {makeup:=>State}",
+				"{i:=>Who} am putting my {makeup:=>State} on",
 				"{i:=>Who} am making my {makeup:=>State}",
 				"{i:=>Who} am {going bed:=>State}",
 				"{i'm:=>Who} {going bed:=>State}",
 				"{we:=>Who} are {going bed:=>State}",
 				"{we:=>Who} are {going to bed:=>State}",
 				"it's {tv time:=>State}",
+				"{going out:=>State}",
 				"prepare for {tv:=>State} please",
 				"please prepare for {us:=>Who} {leaving home:=>State}",
 				"prepare for {eating:=>State} please",


### PR DESCRIPTION
##### Summary

Short term fix to allow certain user events to trigger. Original code was NOT looking for a personDesignation (who) before sending the trigger, therefore a request of " we are going out" would not trigger. 
- That line has been commented and todo'd so that either "going out" or " we are going out" will now trigger the event until further work in this area is looked into

##### What kind of change does this PR introduce?

<!-- Check at least one -->

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring
- [ ] Other, please describe:

##### Does this PR introduce a breaking change?

<!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the path to migrate existing installs to this: -->
###### Migration guide:

<!-- How to migrate from existing Alice's installs -->

##### The PR fulfills these requirements:

- [ ] When resolving/implementing a specific issue, it's referenced in the PR's title (e.g. `fix #xxx` or `implement #xxx`, where "xxx" is the issue number)
- [x] You have tested your changes on the branch you wish to merge
- [x] The changes are working


If adding a **new feature**, the PR's description includes:

- [ ] The reason for this new feature to be added
- [ ] The use of this new feature
- [ ] If available, a link to an existing feature request ticket


###### Other information:
Also added couple of synonyms like " we have" for "we have returned" or "i have returned" etc 